### PR TITLE
fix 332766189685028c4f9852e4285fb1a9025223cc regression

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ matrix:
   allow_failures:
     - go: 1.3
     - go: 1.4
+    - go: tip
   exclude:
     - go: 1.3
       env: SCENARIO=true

--- a/server/peer.go
+++ b/server/peer.go
@@ -171,7 +171,9 @@ func (peer *Peer) processOutgoingPaths(paths, withdrawals []*table.Path) []*tabl
 	outgoing := make([]*table.Path, 0, len(paths))
 	for _, path := range withdrawals {
 		if path.IsLocal() {
-			outgoing = append(outgoing, path)
+			if _, ok := peer.fsm.rfMap[path.GetRouteFamily()]; ok {
+				outgoing = append(outgoing, path)
+			}
 		}
 	}
 

--- a/test/lib/base.py
+++ b/test/lib/base.py
@@ -83,6 +83,7 @@ def make_gobgp_ctn(tag='gobgp', local_gobgp_path='', from_image='osrg/quagga'):
 
     c = CmdBuffer()
     c << 'FROM {0}'.format(from_image)
+    c << 'RUN mkdir -p /go/src/github.com/kr && cd /go/src/github.com/kr && git clone https://github.com/kr/text && cd /go/src/github.com/kr/text && git checkout -b master main'
     c << 'ADD gobgp /go/src/github.com/osrg/gobgp/'
     c << 'RUN go get github.com/osrg/gobgp/gobgpd'
     c << 'RUN go install github.com/osrg/gobgp/gobgpd'


### PR DESCRIPTION
We can't send a path to a peer if the peer isn't configured for its
family.

Signed-off-by: FUJITA Tomonori fujita.tomonori@lab.ntt.co.jp
