### PR TITLE
server: fix isIBGPPeer() to handle local-as configuration

### DIFF
--- a/pkg/server/peer.go
+++ b/pkg/server/peer.go
@@ -140,7 +140,9 @@ func (peer *peer) TableID() string {
 }
 
 func (peer *peer) isIBGPPeer() bool {
-	return peer.fsm.pConf.State.PeerAs == peer.fsm.gConf.Config.As
+	peer.fsm.lock.RLock()
+	defer peer.fsm.lock.RUnlock()
+	return peer.fsm.pConf.State.PeerType == config.PEER_TYPE_INTERNAL
 }
 
 func (peer *peer) isRouteServerClient() bool {


### PR DESCRIPTION
Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>