### PR TITLE
cmd/gobgp: don't use timeout context for requests

### DIFF
--- a/cmd/gobgp/common.go
+++ b/cmd/gobgp/common.go
@@ -202,8 +202,7 @@ func newClient(ctx context.Context) (api.GobgpApiClient, context.CancelFunc, err
 	cc, cancel := context.WithTimeout(ctx, time.Second)
 	conn, err := grpc.DialContext(cc, target, grpcOpts...)
 	if err != nil {
-		cancel()
-		return nil, nil, err
+		return nil, cancel, err
 	}
 	return api.NewGobgpApiClient(conn), cancel, nil
 }

--- a/cmd/gobgp/common.go
+++ b/cmd/gobgp/common.go
@@ -23,6 +23,7 @@ import (
 	"net"
 	"os"
 	"strconv"
+	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -176,7 +177,7 @@ func extractReserved(args []string, keys map[string]int) (map[string][]string, e
 	return m, nil
 }
 
-func newClient(ctx context.Context) (api.GobgpApiClient, error) {
+func newClient(ctx context.Context) (api.GobgpApiClient, context.CancelFunc, error) {
 	grpcOpts := []grpc.DialOption{grpc.WithBlock()}
 	if globalOpts.TLS {
 		var creds credentials.TransportCredentials
@@ -198,12 +199,13 @@ func newClient(ctx context.Context) (api.GobgpApiClient, error) {
 	if target == "" {
 		target = ":50051"
 	}
-
-	conn, err := grpc.DialContext(ctx, target, grpcOpts...)
+	cc, cancel := context.WithTimeout(ctx, time.Second)
+	conn, err := grpc.DialContext(cc, target, grpcOpts...)
 	if err != nil {
-		return nil, err
+		cancel()
+		return nil, nil, err
 	}
-	return api.NewGobgpApiClient(conn), nil
+	return api.NewGobgpApiClient(conn), cancel, nil
 }
 
 func addr2AddressFamily(a net.IP) *api.Family {

--- a/cmd/gobgp/root.go
+++ b/cmd/gobgp/root.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"net/http"
 	_ "net/http/pprof"
-	"time"
 
 	api "github.com/osrg/gobgp/api"
 	"github.com/spf13/cobra"
@@ -58,8 +57,8 @@ func newRootCmd() *cobra.Command {
 
 			if !globalOpts.GenCmpl {
 				var err error
-				ctx, cancel = context.WithTimeout(context.Background(), time.Second)
-				client, err = newClient(ctx)
+				ctx = context.Background()
+				client, cancel, err = newClient(ctx)
 				if err != nil {
 					cancel()
 					exitWithError(err)


### PR DESCRIPTION
timeout context is for only connecting. We should refactor the code to
avoid global context variant.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>