### PR TITLE
travis: fix go vet and fmt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -112,7 +112,7 @@ matrix:
       before_script: go get -u honnef.co/go/tools/cmd/megacheck
       script:
         - test -z "$(go fmt $(go list ./... | grep -v '/vendor/'))"
-        - test -z "$(go vet $(go list ./... | grep -v '/vendor/'))"
+        - go vet $(go list ./... | grep -v '/vendor/')
         - megacheck $(go list ./... | grep -v '/vendor/')
     - <<: *_dep_ensure
       env:


### PR DESCRIPTION
Their error messages go to stderr so even when an error happens, the
length of the stdout is zero so the test passes wrongly.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>