### PR TITLE
make Add/Delete/ListPath APIs symmetric

### DIFF
--- a/internal/pkg/table/path.go
+++ b/internal/pkg/table/path.go
@@ -146,7 +146,12 @@ type Path struct {
 	IsWithdraw       bool
 }
 
+var localSource = &PeerInfo{}
+
 func NewPath(source *PeerInfo, nlri bgp.AddrPrefixInterface, isWithdraw bool, pattrs []bgp.PathAttributeInterface, timestamp time.Time, noImplicitWithdraw bool) *Path {
+	if source == nil {
+		source = localSource
+	}
 	if !isWithdraw && pattrs == nil {
 		log.WithFields(log.Fields{
 			"Topic": "Table",
@@ -323,7 +328,8 @@ func (path *Path) IsLocal() bool {
 }
 
 func (path *Path) IsIBGP() bool {
-	return path.GetSource().AS == path.GetSource().LocalAS
+	as := path.GetSource().AS
+	return (as == path.GetSource().LocalAS) && as != 0
 }
 
 // create new PathAttributes
@@ -380,9 +386,6 @@ func (path *Path) GetRouteFamily() bgp.RouteFamily {
 	return bgp.AfiSafiToRouteFamily(path.OriginInfo().nlri.AFI(), path.OriginInfo().nlri.SAFI())
 }
 
-func (path *Path) SetSource(source *PeerInfo) {
-	path.OriginInfo().source = source
-}
 func (path *Path) GetSource() *PeerInfo {
 	return path.OriginInfo().source
 }

--- a/pkg/server/zclient.go
+++ b/pkg/server/zclient.go
@@ -159,10 +159,9 @@ func newIPRouteBody(dst []*table.Path) (body *zebra.IPRouteBody, isWithdraw bool
 		msgFlags |= zebra.MESSAGE_METRIC
 	}
 	var flags zebra.FLAG
-	info := path.GetSource()
-	if info.AS == info.LocalAS {
+	if path.IsIBGP() {
 		flags = zebra.FLAG_IBGP | zebra.FLAG_INTERNAL
-	} else if info.MultihopTtl > 0 {
+	} else if path.GetSource().MultihopTtl > 0 {
 		flags = zebra.FLAG_INTERNAL
 	}
 	return &zebra.IPRouteBody{


### PR DESCRIPTION
- AddPath() with an api.Path object then DeletePath() works with the same api.Path object.
- ListPath() returns an api.Path object then DeletePath() works with the same api.Path object.

The above is guaranteed with and without PeerInfo (SourceAsn and SourceId).

Signed-off-by: FUJITA Tomonori <fujita.tomonori@gmail.com>