### PR TITLE
gobgp: fix vrf rib command crash

### DIFF
--- a/cmd/gobgp/neighbor.go
+++ b/cmd/gobgp/neighbor.go
@@ -943,7 +943,12 @@ func showNeighborRib(r string, name string, args []string) error {
 			}
 			l := make([]*d, 0, len(rib))
 			for _, dst := range rib {
-				_, p, _ := net.ParseCIDR(dst.Prefix)
+				prefix := dst.Prefix
+				if t == api.TableType_VRF {
+					s := strings.Split(prefix, ":")
+					prefix = s[len(s)-1]
+				}
+				_, p, _ := net.ParseCIDR(prefix)
 				l = append(l, &d{prefix: p.IP, dst: dst})
 			}
 


### PR DESCRIPTION
showNeighborRib() executes net.ParseCIDR() for vrf prefix like
10.100:100:10.0.0.0/24 and then crashes.

Probably ListRib() API should support an option to return sorted
destinations.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@gmail.com>