### PR TITLE
gobgpd: use map for validation table

### DIFF
--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -160,11 +160,11 @@ func toPathApi(path *table.Path, v *table.Validation) *api.Path {
 	return toPathAPI(nil, nil, anyNlri, anyPattrs, path, v)
 }
 
-func getValidation(v []*table.Validation, i int) *table.Validation {
+func getValidation(v map[*table.Path]*table.Validation, p *table.Path) *table.Validation {
 	if v == nil {
 		return nil
 	} else {
-		return v[i]
+		return v[p]
 	}
 }
 


### PR DESCRIPTION
`Table.destinations` is a map, so the order changes.
This commit allows to get validate information from path by using map for validate table

Fix: https://github.com/osrg/gobgp/issues/2223

Signed-off-by: Toshiki Tsuchiya <taruta0811@gmail.com>