### PR TITLE
test: put scenario test dockerfile inside the source tree

### DIFF
--- a/test/lib/fabfile.py
+++ b/test/lib/fabfile.py
@@ -16,15 +16,10 @@ def make_gobgp_ctn(ctx, tag='gobgp',
 
     c = CmdBuffer()
     c << 'FROM {0}'.format(from_image)
-    c << 'COPY gobgp/gobgpd /go/bin/gobgpd'
-    c << 'COPY gobgp/gobgp /go/bin/gobgp'
+    c << 'COPY gobgpd /go/bin/gobgpd'
+    c << 'COPY gobgp /go/bin/gobgp'
 
-    rindex = local_gobgp_path.rindex('gobgp')
-    if rindex < 0:
-        raise Exception('{0} seems not gobgp dir'.format(local_gobgp_path))
-
-    workdir = local_gobgp_path[:rindex]
-    os.chdir(workdir)
+    os.chdir(local_gobgp_path)
     local('echo \'{0}\' > Dockerfile'.format(str(c)))
     local('docker build -t {0} .'.format(tag))
     local('rm Dockerfile')


### PR DESCRIPTION
Avoid using directories outside of the Gobgp source tree on the docker context. Otherwise docker uses a parent directory for its context, which causes slow builds and permission issues